### PR TITLE
Revert "remove unused 'tracks="true"' from addon.xml"

### DIFF
--- a/audiodecoder.sacd/addon.xml.in
+++ b/audiodecoder.sacd/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audiodecoder.sacd"
-  version="0.1.1"
+  version="0.1.2"
   name="SACD ISO support"
   provider-name="Team Kodi, AlwinEsch">
   <requires>@ADDON_DEPENDS@</requires>

--- a/audiodecoder.sacd/addon.xml.in
+++ b/audiodecoder.sacd/addon.xml.in
@@ -9,6 +9,7 @@
     point="kodi.audiodecoder"
     name="sacd"
     extension=".iso|.sacdstream"
+    tracks="true"
     tags="true"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">


### PR DESCRIPTION
Revert "remove unused 'tracks="true"' from addon.xml"

This reverts commit 11f27408effa92a874e4731cd7ceaf2bba766090.

This change has broken his use and playback was no more possible.